### PR TITLE
feat: Implement KTX2File

### DIFF
--- a/cpp/KTX2File.cpp
+++ b/cpp/KTX2File.cpp
@@ -317,7 +317,7 @@ uint32_t KTX2File::startTranscoding()
   return m_transcoder.start_transcoding();
 }
 
-uint32_t KTX2File::transcodeImage(jsi::Object destination, uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format, uint32_t get_alpha_for_opaque_formats, int channel0, int channel1)
+uint32_t KTX2File::transcodeImage(jsi::Object& destination, uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format, uint32_t get_alpha_for_opaque_formats, int channel0, int channel1)
 {
   assert(m_magic == KTX2_MAGIC);
   if (m_magic != KTX2_MAGIC)
@@ -387,6 +387,25 @@ uint32_t KTX2File::transcodeImage(jsi::Object destination, uint32_t level_index,
   
   // TODO: Copy dst_data to destination object.
   return status;
+}
+
+uint32_t KTX2File::getDFD(jsi::Runtime &rt, jsi::Object& destination)
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  
+  auto arrayBuffer = destination.getArrayBuffer(rt);
+  
+  const uint8_vec &dst_data = m_transcoder.get_dfd();
+  
+  if (dst_data.size()) {
+    auto outputBuffer = jsi::ArrayBuffer(std::move(arrayBuffer));
+    memcpy(outputBuffer.data(rt), dst_data.data(), dst_data.size());
+    destination.setProperty(rt, jsi::PropNameID::forAscii(rt, "buffer"), outputBuffer);
+  }
+  
+  return 1;
 }
 
 // TODO: Implement missing methods

--- a/cpp/KTX2File.cpp
+++ b/cpp/KTX2File.cpp
@@ -1,0 +1,397 @@
+#include "KTX2File.h"
+#include <cstring>
+#include <cassert>
+
+using namespace basist;
+using namespace basisu;
+
+namespace facebook::react {
+
+// Based on: https://github.com/BinomialLLC/basis_universal/blob/7c046f89b2c417c70742979204109fd91006c2f2/webgl/transcoder/basis_wrappers.cpp#L536
+KTX2File::KTX2File(jsi::Runtime &rt, const jsi::ArrayBuffer& buffer)
+: m_file([&]() {
+  size_t byteLength = buffer.size(rt);
+  return basisu::vector<uint8_t>(byteLength);
+}()),
+m_is_valid(false),
+m_magic(0)
+{
+  size_t length = buffer.size(rt);
+  
+  // Copy data directly from the input buffer to m_file
+  std::memcpy(m_file.data(), buffer.data(rt), length);
+  
+  if (!m_transcoder.init(m_file.data(), m_file.size()))
+  {
+#if BASISU_DEBUG_PRINTF
+    printf("m_transcoder.init() failed!\n");
+#endif
+    assert(0);
+    m_file.clear();
+  }
+  
+  m_is_valid = true;
+  
+  // Initialized after validation
+  m_magic = KTX2_MAGIC;
+}
+
+bool KTX2File::isValid()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return false;
+  
+  return m_is_valid;
+}
+
+void KTX2File::close()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return;
+  
+  m_file.clear();
+  m_transcoder.clear();
+}
+
+uint32_t KTX2File::getDFDSize()
+{
+  return m_transcoder.get_dfd().size();
+}
+
+bool KTX2File::hasKey(std::string key_name)
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return false;
+  
+  return m_transcoder.find_key(key_name) != nullptr;
+}
+
+uint32_t KTX2File::getTotalKeys()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  
+  return m_transcoder.get_key_values().size();
+}
+
+std::string KTX2File::getKey(uint32_t index)
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return std::string("");
+  
+  return std::string((const char*)m_transcoder.get_key_values()[index].m_key.data());
+}
+
+uint32_t KTX2File::getKeyValueSize(std::string key_name)
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  
+  const uint8_vec* p = m_transcoder.find_key(key_name);
+  return p ? p->size() : 0;
+}
+
+uint32_t KTX2File::getWidth()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_width();
+}
+
+uint32_t KTX2File::getHeight()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_height();
+}
+
+uint32_t KTX2File::getFaces()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_faces();
+}
+
+uint32_t KTX2File::getLayers()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_layers();
+}
+
+uint32_t KTX2File::getLevels()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_levels();
+}
+
+uint32_t KTX2File::getFormat()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return (uint32_t)m_transcoder.get_format();
+}
+
+bool KTX2File::isUASTC()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return false;
+  return m_transcoder.is_uastc();
+}
+
+bool KTX2File::isETC1S()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return false;
+  return m_transcoder.is_etc1s();
+}
+
+bool KTX2File::isHDR()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return false;
+  return m_transcoder.is_hdr();
+}
+
+bool KTX2File::getHasAlpha()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return false;
+  return m_transcoder.get_has_alpha();
+}
+
+uint32_t KTX2File::getDFDColorModel()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_dfd_color_model();
+}
+
+uint32_t KTX2File::getDFDColorPrimaries()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_dfd_color_primaries();
+}
+
+uint32_t KTX2File::getDFDTransferFunc()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_dfd_transfer_func();
+}
+
+uint32_t KTX2File::getDFDFlags()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_dfd_flags();
+}
+
+uint32_t KTX2File::getDFDTotalSamples()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_dfd_total_samples();
+}
+
+uint32_t KTX2File::getDFDChannelID0()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_dfd_channel_id0();
+}
+
+uint32_t KTX2File::getDFDChannelID1()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.get_dfd_channel_id1();
+}
+
+bool KTX2File::isVideo()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  return m_transcoder.is_video();
+}
+
+uint32_t KTX2File::getETC1SImageDescImageFlags(uint32_t level_index, uint32_t layer_index, uint32_t face_index)
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  
+  return m_transcoder.get_etc1s_image_descs_image_flags(level_index, layer_index, face_index);
+}
+
+basist::ktx2_image_level_info KTX2File::getImageLevelInfo(uint32_t level_index, uint32_t layer_index, uint32_t face_index)
+{
+  basist::ktx2_image_level_info info;
+  memset(&info, 0, sizeof(info));
+  
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return info;
+  
+  if (!m_transcoder.get_image_level_info(info, level_index, layer_index, face_index))
+  {
+    assert(0);
+    return info;
+  }
+  
+  return info;
+}
+
+uint32_t KTX2File::getImageTranscodedSizeInBytes(uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format)
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  
+  if (format >= (int)basist::transcoder_texture_format::cTFTotalTextureFormats)
+    return 0;
+  
+  basist::ktx2_image_level_info info;
+  if (!m_transcoder.get_image_level_info(info, level_index, layer_index, face_index))
+    return 0;
+  
+  uint32_t orig_width = info.m_orig_width, orig_height = info.m_orig_height, total_blocks = info.m_total_blocks;
+  
+  const basist::transcoder_texture_format transcoder_format = static_cast<basist::transcoder_texture_format>(format);
+  
+  if (basist::basis_transcoder_format_is_uncompressed(transcoder_format))
+  {
+    const uint32_t bytes_per_pixel = basist::basis_get_uncompressed_bytes_per_pixel(transcoder_format);
+    const uint32_t bytes_per_line = orig_width * bytes_per_pixel;
+    const uint32_t bytes_per_slice = bytes_per_line * orig_height;
+    return bytes_per_slice;
+  }
+  else
+  {
+    const uint32_t bytes_per_block = basist::basis_get_bytes_per_block_or_pixel(transcoder_format);
+    
+    if (transcoder_format == basist::transcoder_texture_format::cTFPVRTC1_4_RGB || transcoder_format == basist::transcoder_texture_format::cTFPVRTC1_4_RGBA)
+    {
+      const uint32_t width = (orig_width + 3) & ~3;
+      const uint32_t height = (orig_height + 3) & ~3;
+      const uint32_t size_in_bytes = (std::max(8U, width) * std::max(8U, height) * 4 + 7) / 8;
+      return size_in_bytes;
+    }
+    
+    return total_blocks * bytes_per_block;
+  }
+}
+
+uint32_t KTX2File::startTranscoding()
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  
+  return m_transcoder.start_transcoding();
+}
+
+uint32_t KTX2File::transcodeImage(jsi::Object destination, uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format, uint32_t get_alpha_for_opaque_formats, int channel0, int channel1)
+{
+  assert(m_magic == KTX2_MAGIC);
+  if (m_magic != KTX2_MAGIC)
+    return 0;
+  
+  if (format >= (int)basist::transcoder_texture_format::cTFTotalTextureFormats)
+    return 0;
+  
+  const basist::transcoder_texture_format transcoder_format = static_cast<basist::transcoder_texture_format>(format);
+  
+  basist::ktx2_image_level_info info;
+  if (!m_transcoder.get_image_level_info(info, level_index, layer_index, face_index))
+    return 0;
+  
+  uint32_t orig_width = info.m_orig_width, orig_height = info.m_orig_height, total_blocks = info.m_total_blocks;
+  
+  basisu::vector<uint8_t> dst_data;
+  
+  uint32_t flags = get_alpha_for_opaque_formats ? basist::cDecodeFlagsTranscodeAlphaDataToOpaqueFormats : 0;
+  
+  uint32_t status;
+  
+  if (basist::basis_transcoder_format_is_uncompressed(transcoder_format))
+  {
+    const uint32_t bytes_per_pixel = basist::basis_get_uncompressed_bytes_per_pixel(transcoder_format);
+    const uint32_t bytes_per_line = orig_width * bytes_per_pixel;
+    const uint32_t bytes_per_slice = bytes_per_line * orig_height;
+    
+    dst_data.resize(bytes_per_slice);
+    
+    status = m_transcoder.transcode_image_level(
+                                                level_index, layer_index, face_index,
+                                                dst_data.data(), orig_width * orig_height,
+                                                transcoder_format,
+                                                flags,
+                                                orig_width,
+                                                orig_height,
+                                                channel0, channel1,
+                                                nullptr);
+  }
+  else
+  {
+    uint32_t bytes_per_block = basist::basis_get_bytes_per_block_or_pixel(transcoder_format);
+    
+    uint32_t required_size = total_blocks * bytes_per_block;
+    
+    if (transcoder_format == basist::transcoder_texture_format::cTFPVRTC1_4_RGB || transcoder_format == basist::transcoder_texture_format::cTFPVRTC1_4_RGBA)
+    {
+      const uint32_t width = (orig_width + 3) & ~3;
+      const uint32_t height = (orig_height + 3) & ~3;
+      required_size = (std::max(8U, width) * std::max(8U, height) * 4 + 7) / 8;
+      assert(required_size >= total_blocks * bytes_per_block);
+    }
+    
+    dst_data.resize(required_size);
+    
+    status = m_transcoder.transcode_image_level(
+                                                level_index, layer_index, face_index,
+                                                dst_data.data(), dst_data.size() / bytes_per_block,
+                                                transcoder_format,
+                                                flags,
+                                                0,
+                                                0,
+                                                channel0, channel1,
+                                                nullptr);
+  }
+  
+  // TODO: Copy dst_data to destination object.
+  return status;
+}
+
+// TODO: Implement missing methods
+// uint32_t transcodeImage
+// uint32_t getKeyValue(std::string key_name, const emscripten::val& dst)
+// ktx2_header_js getHeader()
+// uint32_t getDFD(const emscripten::val& dst)
+}

--- a/cpp/KTX2File.h
+++ b/cpp/KTX2File.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include "rn_basis_universal/transcoder/basisu.h"
+#include "rn_basis_universal/transcoder/basisu_transcoder.h"
+#include <vector>
+#include <string>
+#include <cstdint>
+
+#define KTX2_MAGIC 0xDEADBEE2
+
+namespace facebook::react {
+
+class KTX2File : public jsi::NativeState {
+public:
+  KTX2File(jsi::Runtime &rt, const jsi::ArrayBuffer& buffer);
+  
+  bool isValid();
+  void close();
+  uint32_t getDFDSize();
+  bool hasKey(std::string key_name);
+  uint32_t getTotalKeys();
+  std::string getKey(uint32_t index);
+  uint32_t getKeyValueSize(std::string key_name);
+  uint32_t getWidth();
+  uint32_t getHeight();
+  uint32_t getFaces();
+  uint32_t getLayers();
+  uint32_t getLevels();
+  uint32_t getFormat();
+  bool isUASTC();
+  bool isETC1S();
+  bool isHDR();
+  bool getHasAlpha();
+  uint32_t getDFDColorModel();
+  uint32_t getDFDColorPrimaries();
+  uint32_t getDFDTransferFunc();
+  uint32_t getDFDFlags();
+  uint32_t getDFDTotalSamples();
+  uint32_t getDFDChannelID0();
+  uint32_t getDFDChannelID1();
+  bool isVideo();
+  uint32_t getETC1SImageDescImageFlags(uint32_t level_index, uint32_t layer_index, uint32_t face_index);
+  basist::ktx2_image_level_info getImageLevelInfo(uint32_t level_index, uint32_t layer_index, uint32_t face_index);
+  uint32_t getImageTranscodedSizeInBytes(uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format);
+  uint32_t startTranscoding();
+  uint32_t transcodeImage(jsi::Object destination, uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format, uint32_t get_alpha_for_opaque_formats, int channel0, int channel1);
+  
+private:
+  int m_magic;
+  basist::ktx2_transcoder m_transcoder;
+  basisu::vector<uint8_t> m_file;
+  bool m_is_valid;
+};
+}

--- a/cpp/KTX2File.h
+++ b/cpp/KTX2File.h
@@ -44,7 +44,8 @@ public:
   basist::ktx2_image_level_info getImageLevelInfo(uint32_t level_index, uint32_t layer_index, uint32_t face_index);
   uint32_t getImageTranscodedSizeInBytes(uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format);
   uint32_t startTranscoding();
-  uint32_t transcodeImage(jsi::Object destination, uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format, uint32_t get_alpha_for_opaque_formats, int channel0, int channel1);
+  uint32_t transcodeImage(jsi::Object& destination, uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format, uint32_t get_alpha_for_opaque_formats, int channel0, int channel1);
+  uint32_t getDFD(jsi::Runtime &rt, jsi::Object& destination);
   
 private:
   int m_magic;

--- a/cpp/KTX2File.h
+++ b/cpp/KTX2File.h
@@ -42,9 +42,18 @@ public:
   bool isVideo();
   uint32_t getETC1SImageDescImageFlags(uint32_t level_index, uint32_t layer_index, uint32_t face_index);
   basist::ktx2_image_level_info getImageLevelInfo(uint32_t level_index, uint32_t layer_index, uint32_t face_index);
+  basist::ktx2_header getHeader();
   uint32_t getImageTranscodedSizeInBytes(uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format);
   uint32_t startTranscoding();
-  uint32_t transcodeImage(jsi::Object& destination, uint32_t level_index, uint32_t layer_index, uint32_t face_index, uint32_t format, uint32_t get_alpha_for_opaque_formats, int channel0, int channel1);
+  uint32_t transcodeImage(jsi::Runtime& rt,
+                          jsi::Object& destination,
+                          uint32_t level_index,
+                          uint32_t layer_index,
+                          uint32_t face_index,
+                          uint32_t format,
+                          uint32_t get_alpha_for_opaque_formats,
+                          int channel0,
+                          int channel1);
   uint32_t getDFD(jsi::Runtime &rt, jsi::Object& destination);
   
 private:

--- a/cpp/react-native-basis-universal.cpp
+++ b/cpp/react-native-basis-universal.cpp
@@ -334,8 +334,25 @@ int ReactNativeBasisUniversal::getDFD(jsi::Runtime &rt, jsi::Object handle, jsi:
 }
 
 jsi::Object ReactNativeBasisUniversal::getHeader(jsi::Runtime &rt, jsi::Object handle) {
-  // TODO: Implement getHeader
-  return jsi::Object(rt);
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  auto nativeHeader = ktx2Handle->getHeader();
+  return Bridging<KTX2Header>::toJs(rt, {
+      .dfdByteLength = nativeHeader.m_dfd_byte_length,
+      .dfdByteOffset = nativeHeader.m_dfd_byte_offset,
+      .faceCount = nativeHeader.m_face_count,
+      .layerCount = nativeHeader.m_layer_count,
+      .levelCount = nativeHeader.m_level_count,
+      .vkFormat = nativeHeader.m_vk_format,
+      .typeSize = nativeHeader.m_type_size,
+      .pixelWidth = nativeHeader.m_pixel_width,
+      .pixelHeight = nativeHeader.m_pixel_height,
+      .pixelDepth = nativeHeader.m_pixel_depth,
+      .supercompressionScheme = nativeHeader.m_supercompression_scheme,
+      .kvdByteLength = nativeHeader.m_kvd_byte_length,
+      .kvdByteOffset = nativeHeader.m_kvd_byte_offset,
+      .sgdByteLength = nativeHeader.m_sgd_byte_length,
+      .sgdByteOffset = nativeHeader.m_sgd_byte_offset
+    }, this->jsInvoker_);
 }
 
 bool ReactNativeBasisUniversal::hasKey(jsi::Runtime &rt, jsi::Object handle, jsi::String key) {
@@ -355,36 +372,53 @@ int ReactNativeBasisUniversal::getKeyValueSize(jsi::Runtime &rt, jsi::Object han
   return ktx2Handle->getKeyValueSize(key.utf8(rt));
 }
 
-jsi::Object ReactNativeBasisUniversal::getKeyValue(jsi::Runtime &rt, jsi::Object handle, jsi::String key) {
-  // TODO: Implement getKeyValue
-  return jsi::Object(rt);
-}
-
-int ReactNativeBasisUniversal::getETC1SImageDescImageFlags(jsi::Runtime &rt, jsi::Object handle) {
-  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
-  // TODO: Fix this
-  //  return ktx2Handle->getETC1SImageDescImageFlags();
-  return 0;
-}
-
 jsi::Object ReactNativeBasisUniversal::getImageLevelInfo(jsi::Runtime &rt, jsi::Object handle, int level, int layerIndex, int faceIndex) {
   auto ktx2Handle = tryGetKTX2Handle(rt, handle);
-  // TODO: Fix this
-  ktx2Handle->getImageLevelInfo(level, layerIndex, faceIndex);
-  return jsi::Object(rt);
+  auto nativeInfo = ktx2Handle->getImageLevelInfo(level, layerIndex, faceIndex);
+  return Bridging<KTX2ImageLevelInfo>::toJs(rt, {
+    .levelIndex = nativeInfo.m_level_index,
+    .layerIndex = nativeInfo.m_layer_index,
+    .faceIndex = nativeInfo.m_face_index,
+    .origWidth = nativeInfo.m_orig_width,
+    .origHeight = nativeInfo.m_orig_height,
+    .width = nativeInfo.m_width,
+    .height = nativeInfo.m_height,
+    .numBlocksX = nativeInfo.m_num_blocks_x,
+    .numBlocksY = nativeInfo.m_num_blocks_y,
+    .totalBlocks = nativeInfo.m_total_blocks,
+    .alphaFlag = nativeInfo.m_alpha_flag,
+    .iframeFlag = nativeInfo.m_iframe_flag
+    }, this->jsInvoker_);
 }
 
-int ReactNativeBasisUniversal::getImageTranscodedSizeInBytes(jsi::Runtime &rt, jsi::Object handle, int level, int format) {
+int ReactNativeBasisUniversal::getImageTranscodedSizeInBytes(jsi::Runtime &rt, jsi::Object handle, int levelIndex, int layerIndex, int faceIndex, int format) {
   auto ktx2Handle = tryGetKTX2Handle(rt, handle);
-  // TODO: Fix this
-  // TODO: Implement getImageTranscodedSizeInBytes
-  return 0;
+  return ktx2Handle->getImageTranscodedSizeInBytes(levelIndex, layerIndex, faceIndex, format);
+}
+
+// TODO: Used in IREngine
+int ReactNativeBasisUniversal::transcodeImage(jsi::Runtime &rt, jsi::Object handle, jsi::Object dst, int levelIndex, int layerIndex, int faceIndex, int format, int getAlphaForOpaqueFormats, int channel0, int channel1) {
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  return ktx2Handle->transcodeImage(rt,
+                             dst,
+                             levelIndex,
+                             layerIndex,
+                             faceIndex,
+                             format,
+                             getAlphaForOpaqueFormats,
+                             channel0,
+                             channel1);
 }
 
 
-bool ReactNativeBasisUniversal::transcodeImage(jsi::Runtime &rt, jsi::Object handle, jsi::Object dst, int dstSize, int level, int format, int decodeFlags, int faceIndex, int layerIndex) {
-  // TODO: Implement transcodeImage
-  return false;
+int ReactNativeBasisUniversal::getETC1SImageDescImageFlags(jsi::Runtime &rt, jsi::Object handle, int levelIndex, int layerIndex, int faceIndex) {
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  return ktx2Handle->getETC1SImageDescImageFlags(levelIndex, layerIndex, faceIndex);
+}
+
+int ReactNativeBasisUniversal::getKeyValue(jsi::Runtime &rt, jsi::Object handle, jsi::Object destination) {
+  // TODO: Not implemented (Not used in IREngine)
+  return 0;
 }
 
 }

--- a/cpp/react-native-basis-universal.cpp
+++ b/cpp/react-native-basis-universal.cpp
@@ -21,8 +21,6 @@ void ReactNativeBasisUniversal::NAME(jsi::Runtime &rt, jsi::Object handle) { \
 }
 
 
-
-
 using namespace basist;
 using namespace basisu;
 
@@ -302,7 +300,7 @@ DEFINE_BASIS_ENCODER_PARAMS_SETTER(setHDR, m_hdr, bool);
 
 jsi::Object ReactNativeBasisUniversal::createKTX2FileHandle(jsi::Runtime &rt, jsi::Object data) {
   jsi::Object basisObject{rt};
-//  basisObject.setNativeState(rt, std::make_shared<KTX2File>(rt, data));
+  basisObject.setNativeState(rt, std::make_shared<KTX2File>(rt, data.getArrayBuffer(rt)));
   return basisObject;
 }
 
@@ -330,9 +328,9 @@ GENERATE_KTX2_METHOD(int, getDFDChannelID1);
 GENERATE_KTX2_METHOD(bool, isVideo);
 GENERATE_KTX2_METHOD(bool, startTranscoding);
 
-jsi::Object ReactNativeBasisUniversal::getDFD(jsi::Runtime &rt, jsi::Object handle) {
-  // TODO: Implement getDFD
-  return jsi::Object(rt);
+int ReactNativeBasisUniversal::getDFD(jsi::Runtime &rt, jsi::Object handle, jsi::Object destination) {
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  return ktx2Handle->getDFD(rt, destination);
 }
 
 jsi::Object ReactNativeBasisUniversal::getHeader(jsi::Runtime &rt, jsi::Object handle) {
@@ -341,19 +339,20 @@ jsi::Object ReactNativeBasisUniversal::getHeader(jsi::Runtime &rt, jsi::Object h
 }
 
 bool ReactNativeBasisUniversal::hasKey(jsi::Runtime &rt, jsi::Object handle, jsi::String key) {
-  // TODO: Implement hasKey
-  return false;
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  return ktx2Handle->hasKey(key.utf8(rt));
 }
 
 
 jsi::String ReactNativeBasisUniversal::getKey(jsi::Runtime &rt, jsi::Object handle, int index) {
-  // TODO: Implement getKey
-  return jsi::String::createFromUtf8(rt, "");
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  auto result = ktx2Handle->getKey(index);
+  return jsi::String::createFromUtf8(rt, result);
 }
 
 int ReactNativeBasisUniversal::getKeyValueSize(jsi::Runtime &rt, jsi::Object handle, jsi::String key) {
-  // TODO: Implement getKeyValueSize
-  return 0;
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  return ktx2Handle->getKeyValueSize(key.utf8(rt));
 }
 
 jsi::Object ReactNativeBasisUniversal::getKeyValue(jsi::Runtime &rt, jsi::Object handle, jsi::String key) {
@@ -362,16 +361,22 @@ jsi::Object ReactNativeBasisUniversal::getKeyValue(jsi::Runtime &rt, jsi::Object
 }
 
 int ReactNativeBasisUniversal::getETC1SImageDescImageFlags(jsi::Runtime &rt, jsi::Object handle) {
-  // TODO: Implement getETC1SImageDescImageFlags
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  // TODO: Fix this
+  //  return ktx2Handle->getETC1SImageDescImageFlags();
   return 0;
 }
 
 jsi::Object ReactNativeBasisUniversal::getImageLevelInfo(jsi::Runtime &rt, jsi::Object handle, int level, int layerIndex, int faceIndex) {
-  // TODO: Implement getImageLevelInfo
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  // TODO: Fix this
+  ktx2Handle->getImageLevelInfo(level, layerIndex, faceIndex);
   return jsi::Object(rt);
 }
 
 int ReactNativeBasisUniversal::getImageTranscodedSizeInBytes(jsi::Runtime &rt, jsi::Object handle, int level, int format) {
+  auto ktx2Handle = tryGetKTX2Handle(rt, handle);
+  // TODO: Fix this
   // TODO: Implement getImageTranscodedSizeInBytes
   return 0;
 }

--- a/cpp/react-native-basis-universal.cpp
+++ b/cpp/react-native-basis-universal.cpp
@@ -1,10 +1,26 @@
 #include "react-native-basis-universal.h"
+#include "KTX2File.h"
+#include <valarray>
 
 #define DEFINE_BASIS_ENCODER_PARAMS_SETTER(func_name, param_name, param_type) \
 void ReactNativeBasisUniversal::func_name(jsi::Runtime &rt, jsi::Object handle, param_type flag) { \
   auto encoder = tryGetBasisEncoder(rt, handle); \
   encoder->m_params.param_name = flag; \
 }
+
+#define GENERATE_KTX2_METHOD(RETURN_TYPE, NAME) \
+RETURN_TYPE ReactNativeBasisUniversal::NAME(jsi::Runtime &rt, jsi::Object handle) { \
+    auto ktx2Handle = tryGetKTX2Handle(rt, handle); \
+    return ktx2Handle->NAME(); \
+}
+
+#define GENERATE_KTX2_VOID_METHOD(NAME) \
+void ReactNativeBasisUniversal::NAME(jsi::Runtime &rt, jsi::Object handle) { \
+    auto ktx2Handle = tryGetKTX2Handle(rt, handle); \
+    ktx2Handle->NAME(); \
+}
+
+
 
 
 using namespace basist;
@@ -24,6 +40,15 @@ std::shared_ptr<BasisEncoder> tryGetBasisEncoder(jsi::Runtime& rt, jsi::Object& 
 
   auto encoder = std::dynamic_pointer_cast<BasisEncoder>(basisEncoderObj.getNativeState(rt));
   return encoder;
+}
+
+std::shared_ptr<KTX2File> tryGetKTX2Handle(jsi::Runtime& rt, jsi::Object& kt2xHandle) {
+  if (!kt2xHandle.hasNativeState(rt)) {
+    return nullptr;
+  }
+
+  auto ktx2file = std::dynamic_pointer_cast<KTX2File>(kt2xHandle.getNativeState(rt));
+  return ktx2file;
 }
 
 ReactNativeBasisUniversal::ReactNativeBasisUniversal(std::shared_ptr<CallInvoker> jsInvoker)
@@ -271,4 +296,90 @@ DEFINE_BASIS_ENCODER_PARAMS_SETTER(setComputeStats, m_compute_stats, bool);
 DEFINE_BASIS_ENCODER_PARAMS_SETTER(setCreateKTX2File, m_create_ktx2_file, bool);
 DEFINE_BASIS_ENCODER_PARAMS_SETTER(setDebug, m_debug, bool);
 DEFINE_BASIS_ENCODER_PARAMS_SETTER(setHDR, m_hdr, bool);
+
+
+// KTX2 File
+
+jsi::Object ReactNativeBasisUniversal::createKTX2FileHandle(jsi::Runtime &rt, jsi::Object data) {
+  jsi::Object basisObject{rt};
+//  basisObject.setNativeState(rt, std::make_shared<KTX2File>(rt, data));
+  return basisObject;
+}
+
+GENERATE_KTX2_METHOD(bool, isValid);
+GENERATE_KTX2_METHOD(int, getDFDSize);
+GENERATE_KTX2_VOID_METHOD(close);
+GENERATE_KTX2_METHOD(int, getTotalKeys);
+GENERATE_KTX2_METHOD(int, getWidth);
+GENERATE_KTX2_METHOD(int, getHeight);
+GENERATE_KTX2_METHOD(int, getFaces);
+GENERATE_KTX2_METHOD(int, getLayers);
+GENERATE_KTX2_METHOD(int, getLevels);
+GENERATE_KTX2_METHOD(int, getFormat);
+GENERATE_KTX2_METHOD(bool, isUASTC);
+GENERATE_KTX2_METHOD(bool, isHDR);
+GENERATE_KTX2_METHOD(bool, isETC1S);
+GENERATE_KTX2_METHOD(bool, getHasAlpha);
+GENERATE_KTX2_METHOD(int, getDFDColorModel);
+GENERATE_KTX2_METHOD(int, getDFDColorPrimaries);
+GENERATE_KTX2_METHOD(int, getDFDTransferFunc);
+GENERATE_KTX2_METHOD(int, getDFDFlags);
+GENERATE_KTX2_METHOD(int, getDFDTotalSamples);
+GENERATE_KTX2_METHOD(int, getDFDChannelID0);
+GENERATE_KTX2_METHOD(int, getDFDChannelID1);
+GENERATE_KTX2_METHOD(bool, isVideo);
+GENERATE_KTX2_METHOD(bool, startTranscoding);
+
+jsi::Object ReactNativeBasisUniversal::getDFD(jsi::Runtime &rt, jsi::Object handle) {
+  // TODO: Implement getDFD
+  return jsi::Object(rt);
+}
+
+jsi::Object ReactNativeBasisUniversal::getHeader(jsi::Runtime &rt, jsi::Object handle) {
+  // TODO: Implement getHeader
+  return jsi::Object(rt);
+}
+
+bool ReactNativeBasisUniversal::hasKey(jsi::Runtime &rt, jsi::Object handle, jsi::String key) {
+  // TODO: Implement hasKey
+  return false;
+}
+
+
+jsi::String ReactNativeBasisUniversal::getKey(jsi::Runtime &rt, jsi::Object handle, int index) {
+  // TODO: Implement getKey
+  return jsi::String::createFromUtf8(rt, "");
+}
+
+int ReactNativeBasisUniversal::getKeyValueSize(jsi::Runtime &rt, jsi::Object handle, jsi::String key) {
+  // TODO: Implement getKeyValueSize
+  return 0;
+}
+
+jsi::Object ReactNativeBasisUniversal::getKeyValue(jsi::Runtime &rt, jsi::Object handle, jsi::String key) {
+  // TODO: Implement getKeyValue
+  return jsi::Object(rt);
+}
+
+int ReactNativeBasisUniversal::getETC1SImageDescImageFlags(jsi::Runtime &rt, jsi::Object handle) {
+  // TODO: Implement getETC1SImageDescImageFlags
+  return 0;
+}
+
+jsi::Object ReactNativeBasisUniversal::getImageLevelInfo(jsi::Runtime &rt, jsi::Object handle, int level, int layerIndex, int faceIndex) {
+  // TODO: Implement getImageLevelInfo
+  return jsi::Object(rt);
+}
+
+int ReactNativeBasisUniversal::getImageTranscodedSizeInBytes(jsi::Runtime &rt, jsi::Object handle, int level, int format) {
+  // TODO: Implement getImageTranscodedSizeInBytes
+  return 0;
+}
+
+
+bool ReactNativeBasisUniversal::transcodeImage(jsi::Runtime &rt, jsi::Object handle, jsi::Object dst, int dstSize, int level, int format, int decodeFlags, int faceIndex, int layerIndex) {
+  // TODO: Implement transcodeImage
+  return false;
+}
+
 }

--- a/cpp/react-native-basis-universal.h
+++ b/cpp/react-native-basis-universal.h
@@ -13,6 +13,12 @@
 
 namespace facebook::react {
 
+using KTX2Header = NativeBasisUniversalKTX2Header<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, bool, bool>;
+
+template <>
+struct Bridging<KTX2Header>
+: NativeBasisUniversalKTX2HeaderBridging<KTX2Header> {};
+
 using namespace facebook;
 
 class ReactNativeBasisUniversal : public NativeBasisUniversalCxxSpecJSI {
@@ -58,7 +64,7 @@ public:
   bool isValid(jsi::Runtime &rt, jsi::Object handle) override;
   void close(jsi::Runtime &rt, jsi::Object handle) override;
   int getDFDSize(jsi::Runtime &rt, jsi::Object handle) override;
-  jsi::Object getDFD(jsi::Runtime &rt, jsi::Object handle) override;
+  int getDFD(jsi::Runtime &rt, jsi::Object handle, jsi::Object destination) override;
   jsi::Object getHeader(jsi::Runtime &rt, jsi::Object handle) override;
   bool hasKey(jsi::Runtime &rt, jsi::Object handle, jsi::String key) override;
   int getTotalKeys(jsi::Runtime &rt, jsi::Object handle) override;
@@ -89,6 +95,7 @@ public:
   bool startTranscoding(jsi::Runtime &rt, jsi::Object handle) override;
   bool transcodeImage(jsi::Runtime &rt, jsi::Object handle, jsi::Object dst, int dstSize, int level, int format, int decodeFlags, int faceIndex, int layerIndex) override;
 
+ 
 
 private:
   bool basis_initialized_flag;

--- a/cpp/react-native-basis-universal.h
+++ b/cpp/react-native-basis-universal.h
@@ -13,11 +13,47 @@
 
 namespace facebook::react {
 
-using KTX2Header = NativeBasisUniversalKTX2Header<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, bool, bool>;
+using KTX2Header = NativeBasisUniversalKTX2Header<
+    /* vkFormat */               uint32_t,
+    /* typeSize */               uint32_t,
+    /* pixelWidth */             uint32_t,
+    /* pixelHeight */            uint32_t,
+    /* pixelDepth */             uint32_t,
+    /* layerCount */             uint32_t,
+    /* faceCount */              uint32_t,
+    /* levelCount */             uint32_t,
+    /* supercompressionScheme */ uint32_t,
+    /* dfdByteOffset */          uint32_t,
+    /* dfdByteLength */          uint32_t,
+    /* kvdByteOffset */          uint32_t,
+    /* kvdByteLength */          uint32_t,
+    /* sgdByteOffset */          uint32_t,
+    /* sgdByteLength */          uint32_t
+>;
 
 template <>
 struct Bridging<KTX2Header>
 : NativeBasisUniversalKTX2HeaderBridging<KTX2Header> {};
+
+
+using KTX2ImageLevelInfo = NativeBasisUniversalKTX2ImageLevelInfo<
+    /* levelIndex */  uint32_t,
+    /* layerIndex */  uint32_t,
+    /* faceIndex */   uint32_t,
+    /* origWidth */   uint32_t,
+    /* origHeight */  uint32_t,
+    /* width */       uint32_t,
+    /* height: */     uint32_t,
+    /* numBlocksX */  uint32_t,
+    /* numBlocksY */  uint32_t,
+    /* totalBlocks */ uint32_t,
+    /* alphaFlag */   bool,
+    /* iframeFlag */  bool
+>;
+
+template <>
+struct Bridging<KTX2ImageLevelInfo>
+: NativeBasisUniversalKTX2ImageLevelInfoBridging<KTX2ImageLevelInfo> {};
 
 using namespace facebook;
 
@@ -70,7 +106,7 @@ public:
   int getTotalKeys(jsi::Runtime &rt, jsi::Object handle) override;
   jsi::String getKey(jsi::Runtime &rt, jsi::Object handle, int index) override;
   int getKeyValueSize(jsi::Runtime &rt, jsi::Object handle, jsi::String key) override;
-  jsi::Object getKeyValue(jsi::Runtime &rt, jsi::Object handle, jsi::String key) override;
+  int getKeyValue(jsi::Runtime &rt, jsi::Object handle, jsi::Object destination) override;
   int getWidth(jsi::Runtime &rt, jsi::Object handle) override;
   int getHeight(jsi::Runtime &rt, jsi::Object handle) override;
   int getFaces(jsi::Runtime &rt, jsi::Object handle) override;
@@ -89,13 +125,13 @@ public:
   int getDFDChannelID0(jsi::Runtime &rt, jsi::Object handle) override;
   int getDFDChannelID1(jsi::Runtime &rt, jsi::Object handle) override;
   bool isVideo(jsi::Runtime &rt, jsi::Object handle) override;
-  int getETC1SImageDescImageFlags(jsi::Runtime &rt, jsi::Object handle) override;
+  int getETC1SImageDescImageFlags(jsi::Runtime &rt, jsi::Object handle, int levelIndex, int layerIndex, int faceIndex) override;
   jsi::Object getImageLevelInfo(jsi::Runtime &rt, jsi::Object handle, int level, int layerIndex, int faceIndex) override;
-  int getImageTranscodedSizeInBytes(jsi::Runtime &rt, jsi::Object handle, int level, int format) override;
+  int getImageTranscodedSizeInBytes(jsi::Runtime &rt, jsi::Object handle, int levelIndex, int layerIndex, int faceIndex, int format) override;
   bool startTranscoding(jsi::Runtime &rt, jsi::Object handle) override;
-  bool transcodeImage(jsi::Runtime &rt, jsi::Object handle, jsi::Object dst, int dstSize, int level, int format, int decodeFlags, int faceIndex, int layerIndex) override;
+  int transcodeImage(jsi::Runtime &rt, jsi::Object handle, jsi::Object dst, int levelIndex, int layerIndex, int faceIndex, int format, int getAlphaForOpaqueFormats, int channel0, int channel1) override;
 
- 
+
 
 private:
   bool basis_initialized_flag;

--- a/cpp/react-native-basis-universal.h
+++ b/cpp/react-native-basis-universal.h
@@ -21,6 +21,8 @@ public:
   constexpr static auto kModuleName = "BasisUniversal";
 
   void initializeBasis(jsi::Runtime &rt) override;
+
+  // Basis Encoder
   jsi::Object createBasisHandle(jsi::Runtime &rt) override;
   void setCreateKTX2File(jsi::Runtime &rt, jsi::Object handle, bool flag) override;
   void setDebug(jsi::Runtime &rt, jsi::Object handle, bool flag) override;
@@ -50,6 +52,43 @@ public:
   void setMaxSelectorClusters(jsi::Runtime &rt, jsi::Object handle, int maxClusters) override;
   void setSelectorRDOThresh(jsi::Runtime &rt, jsi::Object handle, double threshold) override;
   void setEndpointRDOThresh(jsi::Runtime &rt, jsi::Object handle, double threshold) override;
+
+  // KTX2 File
+  jsi::Object createKTX2FileHandle(jsi::Runtime &rt, jsi::Object data) override;
+  bool isValid(jsi::Runtime &rt, jsi::Object handle) override;
+  void close(jsi::Runtime &rt, jsi::Object handle) override;
+  int getDFDSize(jsi::Runtime &rt, jsi::Object handle) override;
+  jsi::Object getDFD(jsi::Runtime &rt, jsi::Object handle) override;
+  jsi::Object getHeader(jsi::Runtime &rt, jsi::Object handle) override;
+  bool hasKey(jsi::Runtime &rt, jsi::Object handle, jsi::String key) override;
+  int getTotalKeys(jsi::Runtime &rt, jsi::Object handle) override;
+  jsi::String getKey(jsi::Runtime &rt, jsi::Object handle, int index) override;
+  int getKeyValueSize(jsi::Runtime &rt, jsi::Object handle, jsi::String key) override;
+  jsi::Object getKeyValue(jsi::Runtime &rt, jsi::Object handle, jsi::String key) override;
+  int getWidth(jsi::Runtime &rt, jsi::Object handle) override;
+  int getHeight(jsi::Runtime &rt, jsi::Object handle) override;
+  int getFaces(jsi::Runtime &rt, jsi::Object handle) override;
+  int getLayers(jsi::Runtime &rt, jsi::Object handle) override;
+  int getLevels(jsi::Runtime &rt, jsi::Object handle) override;
+  int getFormat(jsi::Runtime &rt, jsi::Object handle) override;
+  bool isUASTC(jsi::Runtime &rt, jsi::Object handle) override;
+  bool isHDR(jsi::Runtime &rt, jsi::Object handle) override;
+  bool isETC1S(jsi::Runtime &rt, jsi::Object handle) override;
+  bool getHasAlpha(jsi::Runtime &rt, jsi::Object handle) override;
+  int getDFDColorModel(jsi::Runtime &rt, jsi::Object handle) override;
+  int getDFDColorPrimaries(jsi::Runtime &rt, jsi::Object handle) override;
+  int getDFDTransferFunc(jsi::Runtime &rt, jsi::Object handle) override;
+  int getDFDFlags(jsi::Runtime &rt, jsi::Object handle) override;
+  int getDFDTotalSamples(jsi::Runtime &rt, jsi::Object handle) override;
+  int getDFDChannelID0(jsi::Runtime &rt, jsi::Object handle) override;
+  int getDFDChannelID1(jsi::Runtime &rt, jsi::Object handle) override;
+  bool isVideo(jsi::Runtime &rt, jsi::Object handle) override;
+  int getETC1SImageDescImageFlags(jsi::Runtime &rt, jsi::Object handle) override;
+  jsi::Object getImageLevelInfo(jsi::Runtime &rt, jsi::Object handle, int level, int layerIndex, int faceIndex) override;
+  int getImageTranscodedSizeInBytes(jsi::Runtime &rt, jsi::Object handle, int level, int format) override;
+  bool startTranscoding(jsi::Runtime &rt, jsi::Object handle) override;
+  bool transcodeImage(jsi::Runtime &rt, jsi::Object handle, jsi::Object dst, int dstSize, int level, int format, int decodeFlags, int faceIndex, int layerIndex) override;
+
 
 private:
   bool basis_initialized_flag;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import {
   initializeBasis,
   BasisEncoder,
+  KTX2File,
 } from '@callstack/react-native-basis-universal';
 import RNFetchBlob from 'react-native-blob-util';
 
@@ -24,6 +25,134 @@ function arrayBufferToBase64(buffer: Uint8Array): string {
     binary += String.fromCharCode(bytes?.[i] ?? 0);
   }
   return btoa(binary);
+}
+
+function dumpKTX2FileDesc(ktx2File: KTX2File) {
+  console.log('Width: ' + ktx2File.getWidth());
+  console.log('Height: ' + ktx2File.getHeight());
+  console.log('IsHDR: ' + ktx2File.isHDR());
+  console.log('Faces: ' + ktx2File.getFaces());
+  console.log('Layers: ' + ktx2File.getLayers());
+  console.log('Levels: ' + ktx2File.getLevels());
+  console.log('isUASTC: ' + ktx2File.isUASTC());
+  console.log('isETC1S: ' + ktx2File.isETC1S());
+  console.log('Format: ' + ktx2File.getFormat());
+  console.log('Has alpha: ' + ktx2File.getHasAlpha());
+  console.log('Total Keys: ' + ktx2File.getTotalKeys());
+  console.log('DFD Size: ' + ktx2File.getDFDSize());
+  console.log('DFD Color Model: ' + ktx2File.getDFDColorModel());
+  console.log('DFD Color Primaries: ' + ktx2File.getDFDColorPrimaries());
+  console.log('DFD Transfer Function: ' + ktx2File.getDFDTransferFunc());
+  console.log('DFD Flags: ' + ktx2File.getDFDFlags());
+  console.log('DFD Total Samples: ' + ktx2File.getDFDTotalSamples());
+  console.log('DFD Channel0: ' + ktx2File.getDFDChannelID0());
+  console.log('DFD Channel1: ' + ktx2File.getDFDChannelID1());
+  console.log('Is Video: ' + ktx2File.isVideo());
+
+  var dfdSize = ktx2File.getDFDSize();
+  var dvdData = new Uint8Array(dfdSize);
+  ktx2File.getDFD(dvdData);
+
+  console.log('DFD bytes:' + dvdData.toString());
+  console.log('--');
+
+  console.log('--');
+  console.log('Key values:');
+  var key_index;
+  for (key_index = 0; key_index < ktx2File.getTotalKeys(); key_index++) {
+    var key_name = ktx2File.getKey(key_index);
+    console.log('Key ' + key_index + ': "' + key_name + '"');
+
+    // if (valSize != 0) {
+    //   var val_data = new Uint8Array(valSize);
+    //   var status = ktx2File.getKeyValue(key_name, val_data);
+    //   if (!status) console.log('getKeyValue() failed');
+    //   else {
+    //     console.log('value size: ' + val_data.length);
+    //     var i,
+    //       str = '';
+    //
+    //     for (i = 0; i < val_data.length; i++) {
+    //       var c = val_data[i];
+    //       str = str + String.fromCharCode(c);
+    //     }
+    //
+    //     console.log(str);
+    //   }
+    // } else console.log('<empty value>');
+  }
+
+  // console.log('--');
+  // console.log('Image level information:');
+  // var level_index;
+  // for (level_index = 0; level_index < ktx2File.getLevels(); level_index++) {
+  //   var layer_index;
+  //   for (
+  //     layer_index = 0;
+  //     layer_index < Math.max(1, ktx2File.getLayers());
+  //     layer_index++
+  //   ) {
+  //     var face_index;
+  //     for (face_index = 0; face_index < ktx2File.getFaces(); face_index++) {
+  //       var imageLevelInfo = ktx2File.getImageLevelInfo(
+  //         level_index,
+  //         layer_index,
+  //         face_index
+  //       );
+  //
+  //       console.log(
+  //         'level: ' +
+  //           level_index +
+  //           ' layer: ' +
+  //           layer_index +
+  //           ' face: ' +
+  //           face_index
+  //       );
+  //
+  //       console.log('orig_width: ' + imageLevelInfo.origWidth);
+  //       console.log('orig_height: ' + imageLevelInfo.origHeight);
+  //       console.log('width: ' + imageLevelInfo.width);
+  //       console.log('height: ' + imageLevelInfo.height);
+  //       console.log('numBlocksX: ' + imageLevelInfo.numBlocksX);
+  //       console.log('numBlocksY: ' + imageLevelInfo.numBlocksY);
+  //       console.log('totalBlocks: ' + imageLevelInfo.totalBlocks);
+  //       console.log('alphaFlag: ' + imageLevelInfo.alphaFlag);
+  //       console.log('iframeFlag: ' + imageLevelInfo.iframeFlag);
+  //       if (ktx2File.isETC1S())
+  //         console.log(
+  //           'ETC1S image desc image flags: ' +
+  //             ktx2File.getETC1SImageDescImageFlags(
+  //               level_index,
+  //               layer_index,
+  //               face_index
+  //             )
+  //         );
+  //
+  //       console.log('--');
+  //     }
+  //   }
+  // }
+  // console.log('--');
+  console.log('KTX2 header:');
+  // var hdr = ktx2File.getHeader();
+  //
+  // console.log('vkFormat: ' + hdr.vkFormat);
+  // console.log('typeSize: ' + hdr.typeSize);
+  // console.log('pixelWidth: ' + hdr.pixelWidth);
+  // console.log('pixelHeight: ' + hdr.pixelHeight);
+  // console.log('pixelDepth: ' + hdr.pixelDepth);
+  // console.log('layerCount: ' + hdr.layerCount);
+  // console.log('faceCount: ' + hdr.faceCount);
+  // console.log('levelCount: ' + hdr.levelCount);
+  // console.log('superCompressionScheme: ' + hdr.supercompressionScheme);
+  // console.log('dfdByteOffset: ' + hdr.dfdByteOffset);
+  // console.log('dfdByteLength: ' + hdr.dfdByteLength);
+  // console.log('kvdByteOffset: ' + hdr.kvdByteOffset);
+  // console.log('kvdByteLength: ' + hdr.kvdByteLength);
+  // console.log('sgdByteOffset: ' + hdr.sgdByteOffset);
+  // console.log('sgdByteLength: ' + hdr.sgdByteLength);
+
+  console.log('------');
 }
 
 const BlobImage = ({ arrayBuffer }: { arrayBuffer?: Uint8Array | null }) => {
@@ -156,6 +285,11 @@ const BasisEncoderPlayground = () => {
       RNFetchBlob.fs.writeFile(path, Array.from(actualKTX2FileData), 'ascii');
 
       console.log('actualKTX2FileData', actualKTX2FileData.buffer.byteLength);
+
+      console.log('----- KT2XFile -----');
+      const ktx2File = new KTX2File(new Uint8Array(actualKTX2FileData));
+
+      dumpKTX2FileDesc(ktx2File);
     } catch (error) {
       console.error('Encoding failed:', error);
     }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -57,100 +57,72 @@ function dumpKTX2FileDesc(ktx2File: KTX2File) {
   console.log('--');
 
   console.log('--');
-  console.log('Key values:');
-  var key_index;
-  for (key_index = 0; key_index < ktx2File.getTotalKeys(); key_index++) {
-    var key_name = ktx2File.getKey(key_index);
-    console.log('Key ' + key_index + ': "' + key_name + '"');
+  console.log('Image level information:');
+  let level_index;
+  for (level_index = 0; level_index < ktx2File.getLevels(); level_index++) {
+    var layer_index;
+    for (
+      layer_index = 0;
+      layer_index < Math.max(1, ktx2File.getLayers());
+      layer_index++
+    ) {
+      var face_index;
+      for (face_index = 0; face_index < ktx2File.getFaces(); face_index++) {
+        var imageLevelInfo = ktx2File.getImageLevelInfo(
+          level_index,
+          layer_index,
+          face_index
+        );
 
-    // if (valSize != 0) {
-    //   var val_data = new Uint8Array(valSize);
-    //   var status = ktx2File.getKeyValue(key_name, val_data);
-    //   if (!status) console.log('getKeyValue() failed');
-    //   else {
-    //     console.log('value size: ' + val_data.length);
-    //     var i,
-    //       str = '';
-    //
-    //     for (i = 0; i < val_data.length; i++) {
-    //       var c = val_data[i];
-    //       str = str + String.fromCharCode(c);
-    //     }
-    //
-    //     console.log(str);
-    //   }
-    // } else console.log('<empty value>');
+        if (!imageLevelInfo) {
+          continue;
+        }
+
+        console.log(
+          'level: ' +
+            level_index +
+            ' layer: ' +
+            layer_index +
+            ' face: ' +
+            face_index
+        );
+
+        console.log('orig_width: ' + imageLevelInfo.origWidth);
+        console.log('orig_height: ' + imageLevelInfo.origHeight);
+        console.log('width: ' + imageLevelInfo.width);
+        console.log('height: ' + imageLevelInfo.height);
+        console.log('numBlocksX: ' + imageLevelInfo.numBlocksX);
+        console.log('numBlocksY: ' + imageLevelInfo.numBlocksY);
+        console.log('totalBlocks: ' + imageLevelInfo.totalBlocks);
+        console.log('alphaFlag: ' + imageLevelInfo.alphaFlag);
+        console.log('iframeFlag: ' + imageLevelInfo.iframeFlag);
+
+        console.log('--');
+      }
+    }
   }
 
-  // console.log('--');
-  // console.log('Image level information:');
-  // var level_index;
-  // for (level_index = 0; level_index < ktx2File.getLevels(); level_index++) {
-  //   var layer_index;
-  //   for (
-  //     layer_index = 0;
-  //     layer_index < Math.max(1, ktx2File.getLayers());
-  //     layer_index++
-  //   ) {
-  //     var face_index;
-  //     for (face_index = 0; face_index < ktx2File.getFaces(); face_index++) {
-  //       var imageLevelInfo = ktx2File.getImageLevelInfo(
-  //         level_index,
-  //         layer_index,
-  //         face_index
-  //       );
-  //
-  //       console.log(
-  //         'level: ' +
-  //           level_index +
-  //           ' layer: ' +
-  //           layer_index +
-  //           ' face: ' +
-  //           face_index
-  //       );
-  //
-  //       console.log('orig_width: ' + imageLevelInfo.origWidth);
-  //       console.log('orig_height: ' + imageLevelInfo.origHeight);
-  //       console.log('width: ' + imageLevelInfo.width);
-  //       console.log('height: ' + imageLevelInfo.height);
-  //       console.log('numBlocksX: ' + imageLevelInfo.numBlocksX);
-  //       console.log('numBlocksY: ' + imageLevelInfo.numBlocksY);
-  //       console.log('totalBlocks: ' + imageLevelInfo.totalBlocks);
-  //       console.log('alphaFlag: ' + imageLevelInfo.alphaFlag);
-  //       console.log('iframeFlag: ' + imageLevelInfo.iframeFlag);
-  //       if (ktx2File.isETC1S())
-  //         console.log(
-  //           'ETC1S image desc image flags: ' +
-  //             ktx2File.getETC1SImageDescImageFlags(
-  //               level_index,
-  //               layer_index,
-  //               face_index
-  //             )
-  //         );
-  //
-  //       console.log('--');
-  //     }
-  //   }
-  // }
-  // console.log('--');
   console.log('KTX2 header:');
-  // var hdr = ktx2File.getHeader();
-  //
-  // console.log('vkFormat: ' + hdr.vkFormat);
-  // console.log('typeSize: ' + hdr.typeSize);
-  // console.log('pixelWidth: ' + hdr.pixelWidth);
-  // console.log('pixelHeight: ' + hdr.pixelHeight);
-  // console.log('pixelDepth: ' + hdr.pixelDepth);
-  // console.log('layerCount: ' + hdr.layerCount);
-  // console.log('faceCount: ' + hdr.faceCount);
-  // console.log('levelCount: ' + hdr.levelCount);
-  // console.log('superCompressionScheme: ' + hdr.supercompressionScheme);
-  // console.log('dfdByteOffset: ' + hdr.dfdByteOffset);
-  // console.log('dfdByteLength: ' + hdr.dfdByteLength);
-  // console.log('kvdByteOffset: ' + hdr.kvdByteOffset);
-  // console.log('kvdByteLength: ' + hdr.kvdByteLength);
-  // console.log('sgdByteOffset: ' + hdr.sgdByteOffset);
-  // console.log('sgdByteLength: ' + hdr.sgdByteLength);
+  var hdr = ktx2File.getHeader();
+  if (hdr == null) {
+    return;
+  }
+
+  console.log('vkFormat: ' + hdr.vkFormat);
+  console.log('typeSize: ' + hdr.typeSize);
+  console.log('pixelWidth: ' + hdr.pixelWidth);
+  console.log('pixelHeight: ' + hdr.pixelHeight);
+  console.log('pixelDepth: ' + hdr.pixelDepth);
+  console.log('layerCount: ' + hdr.layerCount);
+  console.log('faceCount: ' + hdr.faceCount);
+  console.log('levelCount: ' + hdr.levelCount);
+  console.log('superCompressionScheme: ' + hdr.supercompressionScheme);
+  console.log('dfdByteOffset: ' + hdr.dfdByteOffset);
+  console.log('dfdByteLength: ' + hdr.dfdByteLength);
+  console.log('kvdByteOffset: ' + hdr.kvdByteOffset);
+  console.log('kvdByteLength: ' + hdr.kvdByteLength);
+  console.log('sgdByteOffset: ' + hdr.sgdByteOffset);
+  console.log('sgdByteLength: ' + hdr.sgdByteLength);
 
   console.log('------');
 }
@@ -287,9 +259,43 @@ const BasisEncoderPlayground = () => {
       console.log('actualKTX2FileData', actualKTX2FileData.buffer.byteLength);
 
       console.log('----- KT2XFile -----');
+
+      const t2 = performance.now();
       const ktx2File = new KTX2File(new Uint8Array(actualKTX2FileData));
 
       dumpKTX2FileDesc(ktx2File);
+
+      if (!ktx2File.startTranscoding()) {
+        console.log('startTranscoding failed');
+        console.warn('startTranscoding failed');
+        return;
+      }
+
+      const format = 22; // cTFBC6H
+      const dstSize = ktx2File.getImageTranscodedSizeInBytes(0, 0, 0, format);
+      const dst = new Uint8Array(dstSize);
+
+      console.log('Dst output', dst.slice(0, 100));
+      console.log('Dst size: ' + dstSize);
+
+      if (!ktx2File.transcodeImage(dst, 0, 0, 0, format, 0, -1, -1)) {
+        console.log('ktx2File.transcodeImage failed');
+        console.warn('transcodeImage failed');
+        ktx2File.close();
+        ktx2File.delete();
+
+        return;
+      }
+
+      const t3 = performance.now();
+      console.log(
+        `Call to ktx2File.transcodeImage took ${(t3 - t2) / 1000} seconds.`
+      );
+
+      console.log('Dst output after', dst.slice(0, 100));
+
+      ktx2File.close();
+      ktx2File.delete();
     } catch (error) {
       console.error('Encoding failed:', error);
     }

--- a/src/KTX2File.ts
+++ b/src/KTX2File.ts
@@ -1,6 +1,10 @@
 import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 import NativeBasisUniversal from './NativeBasisUniversal';
-import type { KTX2Header, OpaqueKTX2FileHandle } from './NativeBasisUniversal';
+import type {
+  KTX2Header,
+  KTX2ImageLevelInfo,
+  OpaqueKTX2FileHandle,
+} from './NativeBasisUniversal';
 
 export class KTX2File {
   #nativeKTX2FileHandle: OpaqueKTX2FileHandle | null = null;
@@ -83,10 +87,13 @@ export class KTX2File {
       : 0;
   }
 
-  getKeyValue(key: string): Object | null {
+  getKeyValue(destination: Uint8Array): number {
     return this.#nativeKTX2FileHandle !== null
-      ? NativeBasisUniversal.getKeyValue(this.#nativeKTX2FileHandle, key)
-      : null;
+      ? NativeBasisUniversal.getKeyValue(
+          this.#nativeKTX2FileHandle,
+          destination.buffer
+        )
+      : 0;
   }
 
   getWidth(): Int32 {
@@ -202,10 +209,17 @@ export class KTX2File {
     );
   }
 
-  getETC1SImageDescImageFlags(): Int32 {
+  getETC1SImageDescImageFlags(
+    levelIndex: Int32,
+    layerIndex: Int32,
+    faceIndex: Int32
+  ): Int32 {
     return this.#nativeKTX2FileHandle !== null
       ? NativeBasisUniversal.getETC1SImageDescImageFlags(
-          this.#nativeKTX2FileHandle
+          this.#nativeKTX2FileHandle,
+          levelIndex,
+          layerIndex,
+          faceIndex
         )
       : 0;
   }
@@ -214,7 +228,7 @@ export class KTX2File {
     level: Int32,
     layerIndex: Int32,
     faceIndex: Int32
-  ): Object | null {
+  ): KTX2ImageLevelInfo | null {
     return this.#nativeKTX2FileHandle !== null
       ? NativeBasisUniversal.getImageLevelInfo(
           this.#nativeKTX2FileHandle,
@@ -225,11 +239,18 @@ export class KTX2File {
       : null;
   }
 
-  getImageTranscodedSizeInBytes(level: Int32, format: Int32): Int32 {
+  getImageTranscodedSizeInBytes(
+    levelIndex: Int32,
+    layerIndex: Int32,
+    faceIndex: Int32,
+    format: Int32
+  ): Int32 {
     return this.#nativeKTX2FileHandle !== null
       ? NativeBasisUniversal.getImageTranscodedSizeInBytes(
           this.#nativeKTX2FileHandle,
-          level,
+          levelIndex,
+          layerIndex,
+          faceIndex,
           format
         )
       : 0;
@@ -244,24 +265,26 @@ export class KTX2File {
 
   transcodeImage(
     dst: Uint8Array,
-    dstSize: Int32,
-    level: Int32,
-    format: Int32,
-    decodeFlags: Int32,
+    levelIndex: Int32,
+    layerIndex: Int32,
     faceIndex: Int32,
-    layerIndex: Int32
-  ): boolean {
+    format: Int32,
+    getAlphaForOpaqueFormats: Int32,
+    channel0: Int32,
+    channel1: Int32
+  ): number {
     return this.#nativeKTX2FileHandle !== null
       ? NativeBasisUniversal.transcodeImage(
           this.#nativeKTX2FileHandle,
           dst.buffer,
-          dstSize,
-          level,
-          format,
-          decodeFlags,
+          levelIndex,
+          layerIndex,
           faceIndex,
-          layerIndex
+          format,
+          getAlphaForOpaqueFormats,
+          channel0,
+          channel1
         )
-      : false;
+      : 0;
   }
 }

--- a/src/KTX2File.ts
+++ b/src/KTX2File.ts
@@ -1,6 +1,6 @@
 import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 import NativeBasisUniversal from './NativeBasisUniversal';
-import type { OpaqueKTX2FileHandle } from './NativeBasisUniversal';
+import type { KTX2Header, OpaqueKTX2FileHandle } from './NativeBasisUniversal';
 
 export class KTX2File {
   #nativeKTX2FileHandle: OpaqueKTX2FileHandle | null = null;
@@ -43,13 +43,16 @@ export class KTX2File {
       : 0;
   }
 
-  getDFD(): Object | null {
+  getDFD(destination: Uint8Array): Object | null {
     return this.#nativeKTX2FileHandle !== null
-      ? NativeBasisUniversal.getDFD(this.#nativeKTX2FileHandle)
+      ? NativeBasisUniversal.getDFD(
+          this.#nativeKTX2FileHandle,
+          destination.buffer
+        )
       : null;
   }
 
-  getHeader(): Object | null {
+  getHeader(): KTX2Header | null {
     return this.#nativeKTX2FileHandle !== null
       ? NativeBasisUniversal.getHeader(this.#nativeKTX2FileHandle)
       : null;

--- a/src/KTX2File.ts
+++ b/src/KTX2File.ts
@@ -1,0 +1,264 @@
+import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
+import NativeBasisUniversal from './NativeBasisUniversal';
+import type { OpaqueKTX2FileHandle } from './NativeBasisUniversal';
+
+export class KTX2File {
+  #nativeKTX2FileHandle: OpaqueKTX2FileHandle | null = null;
+
+  constructor(fileData: Uint8Array) {
+    if (this.#nativeKTX2FileHandle == null) {
+      this.#nativeKTX2FileHandle = this.#createNativeBasis(fileData);
+    }
+  }
+
+  #createNativeBasis(fileData: Uint8Array): OpaqueKTX2FileHandle | null {
+    if (!NativeBasisUniversal) {
+      return null;
+    }
+
+    return NativeBasisUniversal.createKTX2FileHandle(fileData.buffer);
+  }
+
+  isValid(): boolean {
+    return (
+      this.#nativeKTX2FileHandle !== null &&
+      NativeBasisUniversal.isValid(this.#nativeKTX2FileHandle)
+    );
+  }
+
+  close(): void {
+    if (this.#nativeKTX2FileHandle !== null) {
+      NativeBasisUniversal.close(this.#nativeKTX2FileHandle);
+      this.#nativeKTX2FileHandle = null;
+    }
+  }
+
+  delete(): void {
+    this.#nativeKTX2FileHandle = null;
+  }
+
+  getDFDSize(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getDFDSize(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getDFD(): Object | null {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getDFD(this.#nativeKTX2FileHandle)
+      : null;
+  }
+
+  getHeader(): Object | null {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getHeader(this.#nativeKTX2FileHandle)
+      : null;
+  }
+
+  hasKey(key: string): boolean {
+    return (
+      this.#nativeKTX2FileHandle !== null &&
+      NativeBasisUniversal.hasKey(this.#nativeKTX2FileHandle, key)
+    );
+  }
+
+  getTotalKeys(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getTotalKeys(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getKey(index: Int32): string | null {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getKey(this.#nativeKTX2FileHandle, index)
+      : null;
+  }
+
+  getKeyValueSize(key: string): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getKeyValueSize(this.#nativeKTX2FileHandle, key)
+      : 0;
+  }
+
+  getKeyValue(key: string): Object | null {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getKeyValue(this.#nativeKTX2FileHandle, key)
+      : null;
+  }
+
+  getWidth(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getWidth(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getHeight(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getHeight(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getFaces(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getFaces(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getLayers(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getLayers(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getLevels(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getLevels(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getFormat(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getFormat(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  isUASTC(): boolean {
+    return (
+      this.#nativeKTX2FileHandle !== null &&
+      NativeBasisUniversal.isUASTC(this.#nativeKTX2FileHandle)
+    );
+  }
+
+  isHDR(): boolean {
+    return (
+      this.#nativeKTX2FileHandle !== null &&
+      NativeBasisUniversal.isHDR(this.#nativeKTX2FileHandle)
+    );
+  }
+
+  isETC1S(): boolean {
+    return (
+      this.#nativeKTX2FileHandle !== null &&
+      NativeBasisUniversal.isETC1S(this.#nativeKTX2FileHandle)
+    );
+  }
+
+  getHasAlpha(): boolean {
+    return (
+      this.#nativeKTX2FileHandle !== null &&
+      NativeBasisUniversal.getHasAlpha(this.#nativeKTX2FileHandle)
+    );
+  }
+
+  getDFDColorModel(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getDFDColorModel(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getDFDColorPrimaries(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getDFDColorPrimaries(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getDFDTransferFunc(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getDFDTransferFunc(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getDFDFlags(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getDFDFlags(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getDFDTotalSamples(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getDFDTotalSamples(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getDFDChannelID0(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getDFDChannelID0(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  getDFDChannelID1(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getDFDChannelID1(this.#nativeKTX2FileHandle)
+      : 0;
+  }
+
+  isVideo(): boolean {
+    return (
+      this.#nativeKTX2FileHandle !== null &&
+      NativeBasisUniversal.isVideo(this.#nativeKTX2FileHandle)
+    );
+  }
+
+  getETC1SImageDescImageFlags(): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getETC1SImageDescImageFlags(
+          this.#nativeKTX2FileHandle
+        )
+      : 0;
+  }
+
+  getImageLevelInfo(
+    level: Int32,
+    layerIndex: Int32,
+    faceIndex: Int32
+  ): Object | null {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getImageLevelInfo(
+          this.#nativeKTX2FileHandle,
+          level,
+          layerIndex,
+          faceIndex
+        )
+      : null;
+  }
+
+  getImageTranscodedSizeInBytes(level: Int32, format: Int32): Int32 {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.getImageTranscodedSizeInBytes(
+          this.#nativeKTX2FileHandle,
+          level,
+          format
+        )
+      : 0;
+  }
+
+  startTranscoding(): boolean {
+    return (
+      this.#nativeKTX2FileHandle !== null &&
+      NativeBasisUniversal.startTranscoding(this.#nativeKTX2FileHandle)
+    );
+  }
+
+  transcodeImage(
+    dst: Uint8Array,
+    dstSize: Int32,
+    level: Int32,
+    format: Int32,
+    decodeFlags: Int32,
+    faceIndex: Int32,
+    layerIndex: Int32
+  ): boolean {
+    return this.#nativeKTX2FileHandle !== null
+      ? NativeBasisUniversal.transcodeImage(
+          this.#nativeKTX2FileHandle,
+          dst.buffer,
+          dstSize,
+          level,
+          format,
+          decodeFlags,
+          faceIndex,
+          layerIndex
+        )
+      : false;
+  }
+}

--- a/src/NativeBasisUniversal.ts
+++ b/src/NativeBasisUniversal.ts
@@ -26,6 +26,21 @@ export type KTX2Header = {
   sgdByteLength: Int32;
 };
 
+export type KTX2ImageLevelInfo = {
+  levelIndex: Int32;
+  layerIndex: Int32;
+  faceIndex: Int32;
+  origWidth: Int32;
+  origHeight: Int32;
+  width: Int32;
+  height: Int32;
+  numBlocksX: Int32;
+  numBlocksY: Int32;
+  totalBlocks: Int32;
+  alphaFlag: boolean;
+  iframeFlag: boolean;
+};
+
 export interface Spec extends TurboModule {
   // Basis
   initializeBasis: () => void;
@@ -122,7 +137,10 @@ export interface Spec extends TurboModule {
   getTotalKeys: (handle: OpaqueKTX2FileHandle) => Int32;
   getKey: (handle: OpaqueKTX2FileHandle, index: Int32) => string;
   getKeyValueSize: (handle: OpaqueKTX2FileHandle, key: string) => Int32;
-  getKeyValue: (handle: OpaqueKTX2FileHandle, key: string) => UnsafeObject;
+  getKeyValue: (
+    handle: OpaqueKTX2FileHandle,
+    destination: UnsafeObject
+  ) => Int32;
   getWidth: (handle: OpaqueKTX2FileHandle) => Int32;
   getHeight: (handle: OpaqueKTX2FileHandle) => Int32;
   getFaces: (handle: OpaqueKTX2FileHandle) => Int32;
@@ -141,29 +159,37 @@ export interface Spec extends TurboModule {
   getDFDChannelID0: (handle: OpaqueKTX2FileHandle) => Int32;
   getDFDChannelID1: (handle: OpaqueKTX2FileHandle) => Int32;
   isVideo: (handle: OpaqueKTX2FileHandle) => boolean;
-  getETC1SImageDescImageFlags: (handle: OpaqueKTX2FileHandle) => Int32;
+  getETC1SImageDescImageFlags: (
+    handle: OpaqueKTX2FileHandle,
+    levelIndex: Int32,
+    layerIndex: Int32,
+    faceIndex: Int32
+  ) => Int32;
   getImageLevelInfo: (
     handle: OpaqueKTX2FileHandle,
     level: Int32,
     layerIndex: Int32,
     faceIndex: Int32
-  ) => UnsafeObject;
+  ) => KTX2ImageLevelInfo;
   getImageTranscodedSizeInBytes: (
     handle: OpaqueKTX2FileHandle,
-    level: Int32,
+    levelIndex: Int32,
+    layerIndex: Int32,
+    faceIndex: Int32,
     format: Int32
   ) => Int32;
   startTranscoding: (handle: OpaqueKTX2FileHandle) => boolean;
   transcodeImage: (
     handle: OpaqueKTX2FileHandle,
     dst: UnsafeObject,
-    dstSize: Int32,
-    level: Int32,
-    format: Int32,
-    decodeFlags: Int32,
+    levelIndex: Int32,
+    layerIndex: Int32,
     faceIndex: Int32,
-    layerIndex: Int32
-  ) => boolean;
+    format: Int32,
+    getAlphaForOpaqueFormats: Int32,
+    channel0: Int32,
+    channel1: Int32
+  ) => Int32;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('BasisUniversal');

--- a/src/NativeBasisUniversal.ts
+++ b/src/NativeBasisUniversal.ts
@@ -8,6 +8,24 @@ import type {
 export type OpaqueNativeBasisHandle = UnsafeObject;
 export type OpaqueKTX2FileHandle = UnsafeObject;
 
+export type KTX2Header = {
+  vkFormat: Int32;
+  typeSize: Int32;
+  pixelWidth: Int32;
+  pixelHeight: Int32;
+  pixelDepth: Int32;
+  layerCount: Int32;
+  faceCount: Int32;
+  levelCount: Int32;
+  supercompressionScheme: Int32;
+  dfdByteOffset: Int32;
+  dfdByteLength: Int32;
+  kvdByteOffset: Int32;
+  kvdByteLength: Int32;
+  sgdByteOffset: Int32;
+  sgdByteLength: Int32;
+};
+
 export interface Spec extends TurboModule {
   // Basis
   initializeBasis: () => void;
@@ -98,8 +116,8 @@ export interface Spec extends TurboModule {
   isValid: (handle: OpaqueKTX2FileHandle) => boolean;
   close: (handle: OpaqueKTX2FileHandle) => void;
   getDFDSize: (handle: OpaqueKTX2FileHandle) => Int32;
-  getDFD: (handle: OpaqueKTX2FileHandle) => UnsafeObject;
-  getHeader: (handle: OpaqueKTX2FileHandle) => UnsafeObject;
+  getDFD: (handle: OpaqueKTX2FileHandle, destination: UnsafeObject) => Int32;
+  getHeader: (handle: OpaqueKTX2FileHandle) => KTX2Header;
   hasKey: (handle: OpaqueKTX2FileHandle, key: string) => boolean;
   getTotalKeys: (handle: OpaqueKTX2FileHandle) => Int32;
   getKey: (handle: OpaqueKTX2FileHandle, index: Int32) => string;

--- a/src/NativeBasisUniversal.ts
+++ b/src/NativeBasisUniversal.ts
@@ -6,6 +6,7 @@ import type {
 } from 'react-native/Libraries/Types/CodegenTypes';
 
 export type OpaqueNativeBasisHandle = UnsafeObject;
+export type OpaqueKTX2FileHandle = UnsafeObject;
 
 export interface Spec extends TurboModule {
   // Basis
@@ -91,6 +92,60 @@ export interface Spec extends TurboModule {
     handle: OpaqueNativeBasisHandle,
     threshold: number
   ) => void;
+
+  // KTX2File
+  createKTX2FileHandle: (data: UnsafeObject) => OpaqueKTX2FileHandle;
+  isValid: (handle: OpaqueKTX2FileHandle) => boolean;
+  close: (handle: OpaqueKTX2FileHandle) => void;
+  getDFDSize: (handle: OpaqueKTX2FileHandle) => Int32;
+  getDFD: (handle: OpaqueKTX2FileHandle) => UnsafeObject;
+  getHeader: (handle: OpaqueKTX2FileHandle) => UnsafeObject;
+  hasKey: (handle: OpaqueKTX2FileHandle, key: string) => boolean;
+  getTotalKeys: (handle: OpaqueKTX2FileHandle) => Int32;
+  getKey: (handle: OpaqueKTX2FileHandle, index: Int32) => string;
+  getKeyValueSize: (handle: OpaqueKTX2FileHandle, key: string) => Int32;
+  getKeyValue: (handle: OpaqueKTX2FileHandle, key: string) => UnsafeObject;
+  getWidth: (handle: OpaqueKTX2FileHandle) => Int32;
+  getHeight: (handle: OpaqueKTX2FileHandle) => Int32;
+  getFaces: (handle: OpaqueKTX2FileHandle) => Int32;
+  getLayers: (handle: OpaqueKTX2FileHandle) => Int32;
+  getLevels: (handle: OpaqueKTX2FileHandle) => Int32;
+  getFormat: (handle: OpaqueKTX2FileHandle) => Int32;
+  isUASTC: (handle: OpaqueKTX2FileHandle) => boolean;
+  isHDR: (handle: OpaqueKTX2FileHandle) => boolean;
+  isETC1S: (handle: OpaqueKTX2FileHandle) => boolean;
+  getHasAlpha: (handle: OpaqueKTX2FileHandle) => boolean;
+  getDFDColorModel: (handle: OpaqueKTX2FileHandle) => Int32;
+  getDFDColorPrimaries: (handle: OpaqueKTX2FileHandle) => Int32;
+  getDFDTransferFunc: (handle: OpaqueKTX2FileHandle) => Int32;
+  getDFDFlags: (handle: OpaqueKTX2FileHandle) => Int32;
+  getDFDTotalSamples: (handle: OpaqueKTX2FileHandle) => Int32;
+  getDFDChannelID0: (handle: OpaqueKTX2FileHandle) => Int32;
+  getDFDChannelID1: (handle: OpaqueKTX2FileHandle) => Int32;
+  isVideo: (handle: OpaqueKTX2FileHandle) => boolean;
+  getETC1SImageDescImageFlags: (handle: OpaqueKTX2FileHandle) => Int32;
+  getImageLevelInfo: (
+    handle: OpaqueKTX2FileHandle,
+    level: Int32,
+    layerIndex: Int32,
+    faceIndex: Int32
+  ) => UnsafeObject;
+  getImageTranscodedSizeInBytes: (
+    handle: OpaqueKTX2FileHandle,
+    level: Int32,
+    format: Int32
+  ) => Int32;
+  startTranscoding: (handle: OpaqueKTX2FileHandle) => boolean;
+  transcodeImage: (
+    handle: OpaqueKTX2FileHandle,
+    dst: UnsafeObject,
+    dstSize: Int32,
+    level: Int32,
+    format: Int32,
+    decodeFlags: Int32,
+    faceIndex: Int32,
+    layerIndex: Int32
+  ) => boolean;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('BasisUniversal');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { initializeBasis } from './Basis';
 import { BasisEncoder } from './BasisEncoder';
+import { KTX2File } from './KTX2File';
 
-export { initializeBasis, BasisEncoder };
+export { initializeBasis, BasisEncoder, KTX2File };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR implements KTX2File class from Basis Universal.

KTX2File
	- [x] `BasisModule.KTX2File( new Uint8Array( buffer ) )`
	- [x] `close()`;
	- [x] `delete()`;
	- [x] `ktx2File.isValid()`
	- [x] `ktx2File.isUASTC()` 
	- [x] `BasisFormat.UASTC_4x4` 
	- [x] `BasisFormat.ETC1S`
	- [x] `ktx2File.getWidth()`
	- [x] `ktx2File.getHeight();`
	- [x] `ktx2File.getLayers()`
	- [x] `ktx2File.getLevels()`
	- [x] `ktx2File.getFaces();`
	- [x] `ktx2File.getHasAlpha();`
	- [x] `ktx2File.getDFDFlags();`
	- [x] `ktx2File.startTranscoding()`
	- [x] `ktx2File.getImageLevelInfo( mip, layer, face );`
	- [x] `ktx2File.getImageTranscodedSizeInBytes();
	- [x] `ktx2File.transcodeImage();`

Preview of file data: 

![CleanShot 2024-10-22 at 15 53 57@2x](https://github.com/user-attachments/assets/2f7364f6-d81b-4cac-90c2-1ef542c020cb)



### Test plan


